### PR TITLE
Add multiple decals upload and reload "hotkey"

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -77,7 +77,8 @@ const DefaultSettings = {
 		Enabled: false,
 		Banners: true,
 		Rectangles: true
-	}
+	},
+	UploadMultipleDecals: true
 }
 
 chrome.runtime.onInstalled.addListener(() => {
@@ -296,3 +297,9 @@ function MergeObjects(obj1, obj2) {
 
 	return mergedObj;
 }
+
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+	if (request.action === 'reload') {
+		chrome.runtime.reload();
+	}
+});

--- a/js/create/image.js
+++ b/js/create/image.js
@@ -1,0 +1,80 @@
+console.log("PolyPlus: Running image.js");
+
+(async () => {
+  var Settings = [];
+  chrome.storage.sync.get(["PolyPlus_Settings"], async function (result) {
+    let Utilities = (await import(chrome.runtime.getURL("resources/utils.js")))
+      .default;
+    Settings = result.PolyPlus_Settings || {
+      UploadMultipleDecals: true,
+    };
+
+    if (Settings.UploadMultipleDecals === true) {
+      UploadMultipleDecals();
+    } else {
+      console.log("PolyPlus: UploadMultipleDecals is disabled");
+    }
+
+    async function UploadMultipleDecals() {
+      const fileInput = document.querySelector("#file");
+      fileInput.setAttribute("multiple", "true");
+
+      const submitBtn = document.querySelector(
+        "#main-content > div:nth-child(4) > div.container.p-0.p-lg-5 > div.row.mx-auto > div.col-lg-10 > div.card.mb-2 > div > form > div.form-group.mb-0 > button"
+      );
+      submitBtn.addEventListener("click", async function (ev) {
+        ev.preventDefault();
+        submitBtn.disabled = true;
+        submitBtn.textContent =
+          "Uploading... (0/" + fileInput.files.length + ")";
+        const files = fileInput.files;
+
+        // we cant submit multiple files to the API, so we create a request for each file
+        let i = 0;
+
+        const uploadFile = async (file, index) => {
+          const formData = new FormData();
+          formData.append("file", file);
+
+          try {
+            const response = await Utilities.RatelimitRepeatingFetch(
+              "https://polytoria.com/create/upload-decal",
+              {
+                method: "POST",
+                body: formData,
+              }
+            );
+
+            console.log(response.status);
+            if (response.ok) {
+              i++;
+              submitBtn.textContent =
+                "Uploading... (" + i + "/" + fileInput.files.length + ")";
+            } else {
+              throw new Error(response.status);
+            }
+          } catch (err) {
+            console.error(err);
+            submitBtn.textContent =
+              "File " + index + " failed to upload: " + err;
+            submitBtn.disabled = false;
+            throw err; // re-throw the error to stop further processing
+          }
+        };
+
+        const uploadFiles = async () => {
+          try {
+            await Promise.all(Array.from(files).map(uploadFile));
+            submitBtn.textContent = "Upload";
+            submitBtn.disabled = false;
+            window.location.reload();
+          } catch (err) {
+            console.error("Some files failed to upload:", err);
+          }
+        };
+
+        uploadFiles();
+      });
+    }
+  });
+})();

--- a/js/sitewide.js
+++ b/js/sitewide.js
@@ -1,6 +1,5 @@
 var Settings;
 let Theme = ``;
-
 (async () => {
 	let Utilities = await import(chrome.runtime.getURL('resources/utils.js'));
 	Utilities = Utilities.default;
@@ -112,6 +111,20 @@ let Theme = ``;
       `;
 		}
 	});
+
+
+  const combination = "reload";
+  let currentCombination = "";
+  document.addEventListener("keypress", function(e) {
+    currentCombination += e.key;
+    if (currentCombination === combination && document.activeElement.tagName !== "INPUT") {
+      console.log("Reloading Poly+...");
+      chrome.runtime.sendMessage({ action: "reload" });
+      window.location.reload();
+    } else if (!combination.startsWith(currentCombination)) {
+      currentCombination = "";
+    }
+  });
 
 	if (Settings.HideUserAds && Settings.HideUserAds.Enabled === true) {
 		if (Settings.HideUserAds.Banners && Settings.HideUserAds.Banners === true) {

--- a/manifest.json
+++ b/manifest.json
@@ -38,6 +38,11 @@
 		},
 
 		{
+			"matches": ["https://polytoria.com/create/image", "https://polytoria.com/create/image/"],
+			"js": ["/js/create/image.js"]
+		},
+
+		{
 			"matches": ["https://polytoria.com/forum/post/**"],
 			"js": ["/js/forum/forum-view.js"]
 		},

--- a/resources/utils.js
+++ b/resources/utils.js
@@ -97,7 +97,8 @@ export default {
 			Enabled: false,
 			Banners: true,
 			Rectangles: true
-		}
+		},
+		UploadMultipleDecals: true,
 	},
 	Limits: {
 		PinnedGames: 10,
@@ -258,5 +259,16 @@ export default {
 		}
 
 		return mergedObj;
+	},
+	RatelimitRepeatingFetch: async function (...args) {
+		const req = await fetch(...args);
+	
+		if (req.status === 429) {
+			const retryAfter = req.headers.get('Retry-After') || 1; // Retry after 1 second if no header is present, else use the header value
+			await new Promise((resolve) => setTimeout(resolve, retryAfter * 1000));
+			return RatelimitRepeatingFetch(...args);
+		}
+	
+		return req;
 	}
 };

--- a/settings.html
+++ b/settings.html
@@ -365,6 +365,17 @@
 					<span style="font-size: 0.8rem; color: orange;">* You can only remove up to <span id="ImprovedFrLists-limit"></span> friends at once.</span>
 				</span>
 			</p>
+			<p class="setting-container" id="upload-multiple-decals">
+				<span class="indicator">&nbsp;</span>
+				<span class="title">
+					Upload multiple decals
+					<button class="btn btn-sm toggle-btn" data-setting="UploadMultipleDecals">Toggle</button>
+				</span>
+				<br />
+				<span class="desc">
+					Lets you quickly upload multiple decals at once!
+				</span>
+			</p>
 			<p class="setting-container" id="irl-price-with-brick-count">
 				<span class="indicator">&nbsp;</span>
 				<span class="title">


### PR DESCRIPTION
This PR adds a new feature, which allows you to upload multiple images at once. If it encounters a ratelimit, it justs waits (Retry-After Header or 1) seconds and tries again.

I also added that when you type "reload" on paulytoria whilst NOT having an input field focused it reloads the extension fully